### PR TITLE
Add new delivery area for Romania.

### DIFF
--- a/pynordpool/const.py
+++ b/pynordpool/const.py
@@ -37,6 +37,8 @@ AREAS = {
     "SE2": "Sweden 2",
     "SE3": "Sweden 3",
     "SE4": "Sweden 4",
+    # Romania
+    "TEL": "Romania",
     # System
     "SYS": "System price",
 }
@@ -50,3 +52,4 @@ class Currency(StrEnum):
     NOK = "NOK"
     PLN = "PLN"
     SEK = "SEK"
+    RON = "RON"


### PR DESCRIPTION
This adds Romania in "AREAS" and the currency "Ron" (Romanian leu) in the "Currency" dataclass enum.

Closes #59

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
